### PR TITLE
Allow running download command from addon's build hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ bower.json.ember-try
 package.json.ember-try
 
 config/crowdin.js
+jsconfig.json

--- a/index.js
+++ b/index.js
@@ -5,14 +5,10 @@ module.exports = {
   excludeFromBuild: false,
 
   preBuild: function() {
-
-    // download translations when build ENV is anything other than development and test
-    if (this.app.env === 'development' || this.app.env === 'test') {
-      return;
+    if (this.app.env !== 'development') {
+      // download consuming application's translations
+      return require('./lib/commands/download').run.call(this.project);
     }
-
-    // this.project is the consuming application
-    return require('./lib/commands/download').run.call(this.project);
   },
 
   config(env, appConfig) {

--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ module.exports = {
       return;
     }
 
-    return require('./lib/commands/download').run.call(this);
+    // this.project is the consuming application
+    return require('./lib/commands/download').run.call(this.project);
   },
 
   config(env, appConfig) {

--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@ module.exports = {
   preBuild: function() {
     if (this.app.env !== 'development') {
       // download consuming application's translations
-      return require('./lib/commands/download').run.call(this.project);
+      return require('./lib/commands/download').run.call(this, {
+        project: this.project
+      });
     }
   },
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ module.exports = {
 
   preBuild: function() {
     if (this.app.env !== 'development') {
-      // download consuming application's translations
+      // download consuming application's translations before it builds
       return require('./lib/commands/download').run.call(this, {
         project: this.project
       });

--- a/lib/commands/download.js
+++ b/lib/commands/download.js
@@ -15,10 +15,10 @@ module.exports = {
   description: 'Download i18n files from Crowdin',
 
   run: function(commandOptions) {
-    let config = loadConfig(this.project.root);
+    let config = loadConfig(this.root);
     let crowdin = getClient(config);
-    let folderName = config.folderName || this.project.pkg.name;
-    let projectRoot = this.project.root;
+    let folderName = config.folderName || this.pkg.name;
+    let projectRoot = this.root;
 
     api.setKey(config.apiKey);
     this.ui.startProgress(`Exporting Crowdin's ${folderName} files`);

--- a/lib/commands/download.js
+++ b/lib/commands/download.js
@@ -15,10 +15,12 @@ module.exports = {
   description: 'Download i18n files from Crowdin',
 
   run: function(commandOptions) {
-    let config = loadConfig(this.root);
+    commandOptions = commandOptions || {};
+    const project = commandOptions.project || this.project;
+    let config = loadConfig(project.root);
     let crowdin = getClient(config);
-    let folderName = config.folderName || this.pkg.name;
-    let projectRoot = this.root;
+    let folderName = config.folderName || project.pkg.name;
+    let projectRoot = project.root;
 
     api.setKey(config.apiKey);
     this.ui.startProgress(`Exporting Crowdin's ${folderName} files`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@outdoorsyco/ember-cli-crowdin",
-  "version": "3.2.0-beta.1",
+  "version": "3.2.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@outdoorsyco/ember-cli-crowdin",
-  "version": "3.1.7",
+  "version": "3.2.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@outdoorsyco/ember-cli-crowdin",
-  "version": "3.2.0-beta.2",
+  "version": "3.2.0-beta.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outdoorsyco/ember-cli-crowdin",
-  "version": "3.1.7",
+  "version": "3.2.0-beta.1",
   "description": "Manages the Crowdin translations for your Ember app from ember-cli",
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outdoorsyco/ember-cli-crowdin",
-  "version": "3.2.0-beta.1",
+  "version": "3.2.0-beta.2",
   "description": "Manages the Crowdin translations for your Ember app from ember-cli",
   "keywords": [
     "ember-addon",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outdoorsyco/ember-cli-crowdin",
-  "version": "3.2.0-beta.2",
+  "version": "3.2.0-beta.3",
   "description": "Manages the Crowdin translations for your Ember app from ember-cli",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
https://app.asana.com/0/347527290763802/1109309314481931/f

Allows an addon to call the `download` function, downloading translations in its own context.

Tested with https://github.com/outdoorsy/outdoorsy-addon/pull/431 and https://github.com/outdoorsy/outdoorsy-search/pull/1231