### PR TITLE
Throw if unhandled promise rejection

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,10 @@ const Funnel = require('broccoli-funnel');
 const fs = require('fs');
 const downloadTranslations = require('./lib/commands/download');
 
+process.on('unhandledRejection', error => {
+  throw error;
+});
+
 module.exports = {
   name: require('./package').name,
   excludeFromBuild: false,
@@ -19,6 +23,8 @@ module.exports = {
     ) {
       return this._downloadTranslations().then(() => {
         this.hasDownloadedTranslations = true;
+      }).catch((error) => {
+        throw error;
       });
     }
   },
@@ -65,6 +71,8 @@ module.exports = {
       });
     });
 
-    return Promise.all([appPromise].concat(addonsPromises));
+    return Promise.all([appPromise].concat(addonsPromises)).catch((error) => {
+      throw error;
+    });
   }
 };

--- a/lib/commands/download.js
+++ b/lib/commands/download.js
@@ -73,6 +73,8 @@ module.exports = {
         .on('error', reject);
 
         this.ui.stopProgress();
+      }).catch((error) => {
+        throw error;
       });
     });
   }


### PR DESCRIPTION
Make sure if an unhandled promise rejection occurs when running a crowdin command, it fails Circle CI.

We were seeing situations where an error occurred, but circle still moved onto deployment: https://circleci.com/gh/outdoorsy/outdoorsy-search/11914

https://github.com/outdoorsy/outdoorsy-search/pull/1255

Here's an example of it at work: https://circleci.com/gh/outdoorsy/outdoorsy-search/11939