### PR TITLE
Wait until build status is not in progress

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     browser: true
   },
   rules: {
+    'no-console': ['error', { allow: ['info', 'error'] }]
   },
   overrides: [
     // node files

--- a/lib/commands/download.js
+++ b/lib/commands/download.js
@@ -5,6 +5,7 @@ const unzip = require('unzipper');
 const api = require('@outdoorsyco/crowdin-api');
 const loadConfig = require('../utils/config');
 const getClient = require('../utils/client');
+const waitAndExport = require('../utils/wait-and-export');
 
 module.exports = {
   name: 'i18n:download',
@@ -26,7 +27,8 @@ module.exports = {
     this.ui.startProgress(`Exporting Crowdin's ${folderName} files`);
 
     return new Promise((resolve, reject) => {
-      return api.exportTranslations(config.projectName).then(result => {
+      return waitAndExport(config.projectName, folderName).then(result => {
+        console.info('---------------', folderName);
         this.ui.stopProgress();
         this.ui.writeLine(`Crowdin build status: ${chalk.green(result.success.status)}`);
 

--- a/lib/commands/report.js
+++ b/lib/commands/report.js
@@ -8,6 +8,7 @@ const rimraf = require('rimraf');
 const yaml = require('js-yaml');
 const api = require('@outdoorsyco/crowdin-api');
 const loadConfig = require('../utils/config');
+const waitAndExport = require('../utils/wait-and-export');
 
 module.exports = {
   name: 'i18n:report',
@@ -21,7 +22,7 @@ module.exports = {
     api.setKey(config.apiKey)
 
     return new Promise((resolve, reject) => {
-      api.exportTranslations(config.projectName).then(result => {
+      waitAndExport(config.projectName).then(result => {
         this.ui.writeLine(chalk.green(`Crowdin build status: ${result.success.status}`));
 
         let translations = [];

--- a/lib/utils/wait-and-export.js
+++ b/lib/utils/wait-and-export.js
@@ -1,0 +1,29 @@
+const api = require('@outdoorsyco/crowdin-api');
+const MAX_ATTEMPTS = 20;
+
+module.exports = function (projectName, folderName) {
+  return new Promise((resolve, reject) => {
+    let attempts = 0;
+    (function checkForSuccess(){
+      api.translationExportStatus(projectName).then(({ status }) => {
+        if (status === 'in-progress') {
+          attempts++;
+          if (attempts >= MAX_ATTEMPTS) {
+            return reject(`\nExport status for ${folderName || projectName} in-progress for too long.  Aborting…`);
+          }
+          console.info(`\nprevious build for ${folderName || projectName} is in progress.  Waiting 5 seconds…`);
+          setTimeout(checkForSuccess, 5000);
+        } else {
+          console.info(`\nstatus is ${status} for ${folderName || projectName}!  exporting…`)
+          api.exportTranslations(projectName).then((result) => {
+            resolve(result);
+          }).catch((error) => {
+            reject(error);
+          })
+        }
+      })
+    })();
+    
+  })
+};
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outdoorsyco/ember-cli-crowdin",
-  "version": "3.2.5",
+  "version": "3.2.6-beta.1",
   "description": "Manages the Crowdin translations for your Ember app from ember-cli",
   "keywords": [
     "ember-addon",
@@ -30,7 +30,7 @@
     "push:git": "git push --tags origin HEAD:master"
   },
   "dependencies": {
-    "@outdoorsyco/crowdin-api": "^2.1.3",
+    "@outdoorsyco/crowdin-api": "2.1.4",
     "crowdin-node": "github:outdoorsy/crowdin-node#updates",
     "ember-cli-babel": "^6.12.0",
     "minimatch": "^3.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,10 +197,10 @@
   dependencies:
     "@glimmer/di" "^0.2.0"
 
-"@outdoorsyco/crowdin-api@^2.1.3":
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/@outdoorsyco/crowdin-api/-/crowdin-api-2.1.3.tgz#6c5701395f85540b6259e76bc36932523812a56f"
-  integrity sha512-wpJkJBvhD1D0kn/5y5pTZ/Lke9fk+gXwDXAzq4OG8MP1JGVMdmlh0YI9fXKBoOZZfl7ebCoz8iXqNBkXf/CcZA==
+"@outdoorsyco/crowdin-api@2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@outdoorsyco/crowdin-api/-/crowdin-api-2.1.4.tgz#e43231fe1696c3c0f618e94c8c8899e85ac60c50"
+  integrity sha512-M73mgT/CN/z08qUJw1aBB+YvIBBDDc2OZTrxWFuYrGlsUqmqW+k1Mi7FQvkehtajLhj5euD5t1MPKAzcJXiAmQ==
   dependencies:
     request "^2.81.0"
     request-promise-native "^1.0.5"


### PR DESCRIPTION
Fixes all of the `Project not built. The build was canceled or interrupted by another build in progress` errors we've been seeing.  Checks the status of the previous build, and waits until it's not in progress.

https://github.com/outdoorsy/outdoorsy-search/pull/1256
https://github.com/outdoorsy/outdoorsy-dashboard/pull/1078