### PR TITLE
Cache downloads

### DIFF
--- a/index.js
+++ b/index.js
@@ -60,19 +60,23 @@ module.exports = {
       project: this.project
     });
 
+    return appPromise.then(() => {
+      return Promise.all(this._addonsPromises());
+    }).catch((error) => {
+      throw error;
+    });
+  },
+
+  _addonsPromises() {
     // download all addons' translations
     const outdoorsyAddonsWithTranslations = this.project.addons.filter((addon) => {
       const path = addon.root;
       return path.includes('outdoorsyco') && fs.existsSync(`${path}/config/crowdin.js`);
     });
-    const addonsPromises = outdoorsyAddonsWithTranslations.map((addon) => {
+    return outdoorsyAddonsWithTranslations.map((addon) => {
       downloadTranslations.run.call(this, {
         project: addon
       });
-    });
-
-    return Promise.all([appPromise].concat(addonsPromises)).catch((error) => {
-      throw error;
     });
   }
 };

--- a/lib/commands/download.js
+++ b/lib/commands/download.js
@@ -1,4 +1,4 @@
-const fs = require('fs');
+const fs = require('fs-extra');
 const path = require('path');
 const chalk = require('chalk');
 const unzip = require('unzipper');
@@ -22,57 +22,68 @@ module.exports = {
     let crowdin = getClient(config);
     let folderName = config.folderName || project.pkg.name;
     let projectRoot = project.root;
+    const translationCacheDirectory = 'tmp/translation-cache';
+    const allTranslationsZip = `${translationCacheDirectory}/all-translations.zip`;
+    if (fs.existsSync(allTranslationsZip)) {
+      this.ui.writeLine(`Already have all translations downloaded`);
+      this.ui.writeLine(`Extracting ${folderName} files from cache`);
+    } else {
+      fs.ensureDirSync(translationCacheDirectory);
+      this.ui.writeLine('Downloading all translations');
+    }
 
     api.setKey(config.apiKey);
     this.ui.startProgress(`Exporting Crowdin's ${folderName} files`);
 
     return new Promise((resolve, reject) => {
       return waitAndExport(config.projectName, folderName).then(result => {
-        console.info('---------------', folderName);
         this.ui.stopProgress();
         this.ui.writeLine(`Crowdin build status: ${chalk.green(result.success.status)}`);
 
         this.ui.startProgress(`Downloading ${folderName} assets and translations`);
-        crowdin.download()
-        .pipe(unzip.Parse())
-        .on('entry', entry => {
-          let isThisProject = entry.path.split('/').includes(folderName);
-          if(isThisProject && entry.type !== 'Directory' && !entry.path.includes("en.yaml")){
-            let relPath = entry.path.replace(`${folderName}/`, '');
-            let fullPath = path.join(projectRoot, relPath);
-            let isAsset = !relPath.includes('.yaml');
-            let hasAssets = commandOptions && commandOptions.assets;
+        crowdin.download().pipe(fs.createWriteStream(allTranslationsZip))
+        .on('finish', () => {
+          fs.createReadStream(allTranslationsZip)
+          .pipe(unzip.Parse())
+          .on('entry', entry => {
+            let isThisProject = entry.path.split('/').includes(folderName);
+            if(isThisProject && entry.type !== 'Directory' && !entry.path.includes("en.yaml")){
+              let relPath = entry.path.replace(`${folderName}/`, '');
+              let fullPath = path.join(projectRoot, relPath);
+              let isAsset = !relPath.includes('.yaml');
+              let hasAssets = commandOptions && commandOptions.assets;
 
 
-            if(config.assetPaths && config.assetPaths.length && isAsset) {
-              if(hasAssets) {
-                config.assetPaths.forEach((asset) => {
-                  let assetLocaleIndex = asset.exportPattern.split('/').indexOf('%locale%');
-                  let splitPath = relPath.split('/');
-                  let locale = splitPath[assetLocaleIndex];
-                  splitPath[assetLocaleIndex] = locale.toLowerCase();
-                  let lcLocalePath = path.join(...splitPath);
-                  let relEntryPath = entry.path.replace(`${folderName}/`, '');
-                  fullPath = path.join(projectRoot, lcLocalePath);
-                  if(relEntryPath.toLowerCase() === lcLocalePath) {
-                    createFolderFor(entry, fullPath);
-                  }
-                });
-              } else {
-                entry.autodrain();
-                return;
+              if(config.assetPaths && config.assetPaths.length && isAsset) {
+                if(hasAssets) {
+                  config.assetPaths.forEach((asset) => {
+                    let assetLocaleIndex = asset.exportPattern.split('/').indexOf('%locale%');
+                    let splitPath = relPath.split('/');
+                    let locale = splitPath[assetLocaleIndex];
+                    splitPath[assetLocaleIndex] = locale.toLowerCase();
+                    let lcLocalePath = path.join(...splitPath);
+                    let relEntryPath = entry.path.replace(`${folderName}/`, '');
+                    fullPath = path.join(projectRoot, lcLocalePath);
+                    if(relEntryPath.toLowerCase() === lcLocalePath) {
+                      createFolderFor(entry, fullPath);
+                    }
+                  });
+                } else {
+                  entry.autodrain();
+                  return;
+                }
               }
-            }
 
-            entry.pipe(fs.createWriteStream(fullPath));
-            this.ui.writeLine(chalk.green(`Downloaded file ${entry.path}`));
-          } else {
-            entry.autodrain();
-          }
+              entry.pipe(fs.createWriteStream(fullPath));
+              this.ui.writeLine(chalk.green(`Downloaded file ${entry.path}`));
+            } else {
+              entry.autodrain();
+            }
+          })
+          .on('close', resolve)
+          .on('end', resolve)
+          .on('error', reject);
         })
-        .on('close', resolve)
-        .on('end', resolve)
-        .on('error', reject);
 
         this.ui.stopProgress();
       }).catch((error) => {

--- a/lib/commands/download.js
+++ b/lib/commands/download.js
@@ -7,6 +7,10 @@ const loadConfig = require('../utils/config');
 const getClient = require('../utils/client');
 const waitAndExport = require('../utils/wait-and-export');
 
+const CACHE_MINUTES = 5;
+const translationCacheDirectory = 'tmp/translation-cache';
+const allTranslationsZip = `${translationCacheDirectory}/all-translations.zip`;
+
 module.exports = {
   name: 'i18n:download',
   aliases: ['i18n:dl'],
@@ -18,80 +22,101 @@ module.exports = {
   run: function(commandOptions) {
     commandOptions = commandOptions || {};
     const project = commandOptions.project || this.project;
-    let config = loadConfig(project.root);
-    let crowdin = getClient(config);
-    let folderName = config.folderName || project.pkg.name;
-    let projectRoot = project.root;
-    const translationCacheDirectory = 'tmp/translation-cache';
-    const allTranslationsZip = `${translationCacheDirectory}/all-translations.zip`;
+    const config = loadConfig(project.root);
+    const crowdin = getClient(config);
+    const folderName = config.folderName || project.pkg.name;
+    const projectRoot = project.root;
+
+    this.ui.writeLine(chalk.cyan(`---- Getting translations for ${folderName} ----`));
+
+    // First, check if the zip exists on disk already
     if (fs.existsSync(allTranslationsZip)) {
-      this.ui.writeLine(`Already have all translations downloaded`);
-      this.ui.writeLine(`Extracting ${folderName} files from cache`);
+      const stats = fs.statSync(allTranslationsZip);
+      const ageInMinutes = (new Date() - new Date(stats.mtime)) / 1000 / 60;
+      if (ageInMinutes > CACHE_MINUTES) {
+        this.ui.writeLine(chalk.red('Translations cache expired'));
+      } else {
+        this.ui.writeLine(chalk.green(
+          `Already have all translations downloaded. Getting ${folderName} files from disk`
+        ));
+        return extractFiles({ folderName, projectRoot, commandOptions, config, ui: this.ui });
+      }
     } else {
+
+      // If not, make sure the directory exists and download translation from crowdin
       fs.ensureDirSync(translationCacheDirectory);
-      this.ui.writeLine('Downloading all translations');
     }
 
     api.setKey(config.apiKey);
-    this.ui.startProgress(`Exporting Crowdin's ${folderName} files`);
 
-    return new Promise((resolve, reject) => {
-      return waitAndExport(config.projectName, folderName).then(result => {
-        this.ui.stopProgress();
-        this.ui.writeLine(`Crowdin build status: ${chalk.green(result.success.status)}`);
-
-        this.ui.startProgress(`Downloading ${folderName} assets and translations`);
+    this.ui.writeLine(chalk.yellow(
+      `Building and downloading all assets and translations from crowdin`
+    ));
+    return waitAndExport(config.projectName, folderName).then(result => {
+      this.ui.writeLine(`Crowdin build status: ${chalk.green(result.success.status)}`);
+      return new Promise((resolve, reject) => {
+        // Download all translations and write zip to disk
         crowdin.download().pipe(fs.createWriteStream(allTranslationsZip))
         .on('finish', () => {
-          fs.createReadStream(allTranslationsZip)
-          .pipe(unzip.Parse())
-          .on('entry', entry => {
-            let isThisProject = entry.path.split('/').includes(folderName);
-            if(isThisProject && entry.type !== 'Directory' && !entry.path.includes("en.yaml")){
-              let relPath = entry.path.replace(`${folderName}/`, '');
-              let fullPath = path.join(projectRoot, relPath);
-              let isAsset = !relPath.includes('.yaml');
-              let hasAssets = commandOptions && commandOptions.assets;
-
-
-              if(config.assetPaths && config.assetPaths.length && isAsset) {
-                if(hasAssets) {
-                  config.assetPaths.forEach((asset) => {
-                    let assetLocaleIndex = asset.exportPattern.split('/').indexOf('%locale%');
-                    let splitPath = relPath.split('/');
-                    let locale = splitPath[assetLocaleIndex];
-                    splitPath[assetLocaleIndex] = locale.toLowerCase();
-                    let lcLocalePath = path.join(...splitPath);
-                    let relEntryPath = entry.path.replace(`${folderName}/`, '');
-                    fullPath = path.join(projectRoot, lcLocalePath);
-                    if(relEntryPath.toLowerCase() === lcLocalePath) {
-                      createFolderFor(entry, fullPath);
-                    }
-                  });
-                } else {
-                  entry.autodrain();
-                  return;
-                }
-              }
-
-              entry.pipe(fs.createWriteStream(fullPath));
-              this.ui.writeLine(chalk.green(`Downloaded file ${entry.path}`));
-            } else {
-              entry.autodrain();
-            }
-          })
-          .on('close', resolve)
-          .on('end', resolve)
-          .on('error', reject);
+          return extractFiles({ folderName, projectRoot, commandOptions, config, ui: this.ui }).then(() => {
+            resolve();
+          }).catch((error) => {
+            reject(error);
+          });
         })
-
-        this.ui.stopProgress();
-      }).catch((error) => {
-        throw error;
-      });
+      })
+    }).catch((error) => {
+      throw error;
     });
-  }
+  },
 };
+
+// Extract files for this folder from zip file to translation folder for correct project
+function extractFiles({ folderName, projectRoot, commandOptions, config, ui }) {
+  return new Promise((resolve, reject) => {
+    ui.writeLine(chalk.green(`Extracting ${folderName} assets and translations`));
+    fs.createReadStream(allTranslationsZip)
+    .pipe(unzip.Parse())
+    .on('entry', entry => {
+      let isThisProject = entry.path.split('/').includes(folderName);
+      if(isThisProject && entry.type !== 'Directory' && !entry.path.includes("en.yaml")){
+        let relPath = entry.path.replace(`${folderName}/`, '');
+        let fullPath = path.join(projectRoot, relPath);
+        let isAsset = !relPath.includes('.yaml');
+        let hasAssets = commandOptions && commandOptions.assets;
+
+
+        if(config.assetPaths && config.assetPaths.length && isAsset) {
+          if(hasAssets) {
+            config.assetPaths.forEach((asset) => {
+              let assetLocaleIndex = asset.exportPattern.split('/').indexOf('%locale%');
+              let splitPath = relPath.split('/');
+              let locale = splitPath[assetLocaleIndex];
+              splitPath[assetLocaleIndex] = locale.toLowerCase();
+              let lcLocalePath = path.join(...splitPath);
+              let relEntryPath = entry.path.replace(`${folderName}/`, '');
+              fullPath = path.join(projectRoot, lcLocalePath);
+              if(relEntryPath.toLowerCase() === lcLocalePath) {
+                createFolderFor(entry, fullPath);
+              }
+            });
+          } else {
+            entry.autodrain();
+            return;
+          }
+        }
+
+        entry.pipe(fs.createWriteStream(fullPath));
+        ui.writeLine(chalk.green(`Extracted file ${entry.path}`));
+      } else {
+        entry.autodrain();
+      }
+    })
+    .on('close', resolve)
+    .on('end', resolve)
+    .on('error', reject);
+  })
+}
 
 function createFolderFor(entry, fullPath) {
   let fileName = entry.type === 'File' ? path.parse(entry.path).base : null;

--- a/lib/utils/wait-and-export.js
+++ b/lib/utils/wait-and-export.js
@@ -14,7 +14,6 @@ module.exports = function (projectName, folderName) {
           console.info(`\nprevious build for ${folderName || projectName} is in progress.  Waiting 5 seconds…`);
           setTimeout(checkForSuccess, 5000);
         } else {
-          console.info(`\nstatus is ${status} for ${folderName || projectName}!  exporting…`)
           api.exportTranslations(projectName).then((result) => {
             resolve(result);
           }).catch((error) => {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@outdoorsyco/crowdin-api": "2.1.4",
     "crowdin-node": "github:outdoorsy/crowdin-node#updates",
     "ember-cli-babel": "^6.12.0",
+    "fs-extra": "^7.0.1",
     "minimatch": "^3.0.4",
     "unzipper": "^0.8.14"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3539,7 +3539,7 @@ fs-extra@^6.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-extra@^7.0.0:
+fs-extra@^7.0.0, fs-extra@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-7.0.1.tgz#4f189c44aa123b895f722804f55ea23eadc348e9"
   integrity sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==


### PR DESCRIPTION
https://app.asana.com/0/1115876435717248/1117905709932876

Every time we do a translation download, it downloads _all_ assets, across all projects.  So let's only do that once, save to disk, and pull from that saved file every subsequent time.

Before, on every app build, we were downloading all of the assets for each of the app itself and its addons.  This was not only wasteful, but was causing API errors.

https://github.com/outdoorsy/outdoorsy-search/pull/1258
https://github.com/outdoorsy/wheelbase-dashboard/pull/723

https://odc-lab-translation-cache.herokuapp.com/

![image](https://user-images.githubusercontent.com/11724146/55819825-48e91900-5abf-11e9-8c66-fa25e1f0b027.png)

![image](https://user-images.githubusercontent.com/11724146/55819665-ed1e9000-5abe-11e9-8652-55f156270f66.png)
