### PR TITLE
Add option to omit translation validation

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ module.exports = {
 
   postBuild(results) {
     if (
-      !['test', 'development'].includes(this.app.env)
+      process.env.VALIDATE !== 'false'
+      && !['test', 'development'].includes(this.app.env)
       // if this is ember-cli-crowdin itself, there's nothing to validate
       && !this.project.root.includes('ember-cli-crowdin')
     ) {

--- a/lib/commands/validate.js
+++ b/lib/commands/validate.js
@@ -29,6 +29,7 @@ module.exports = {
     } else {
       this.ui.writeLine(chalk.red('Some translations were missing.  Validation failed.'));
       this.ui.writeLine(chalk.red('You may need to run ember i18n:download'));
+      this.ui.writeLine(chalk.red('or ember i18n:upload if you have any new keys'));
       throw('Failing build');
     }
 
@@ -73,7 +74,7 @@ module.exports = {
         sourceSubProjectKeys.forEach((key) => {
           if (!parentAppCompiledKeysForLocale.includes(key)) {
             this.ui.writeLine(chalk.red(
-              `missing key ${key} from project ${sourceSubProjectName}`
+              `missing key: ${key}, file: ${path}, project: ${sourceSubProjectName}`
             ));
             this.translationsValid = false;
           }

--- a/lib/commands/validate.js
+++ b/lib/commands/validate.js
@@ -62,7 +62,7 @@ module.exports = {
         this.ui.writeLine(chalk.red(
           `Did you remember to run ember i18n:download?`
         ));
-        throw('Validation failed');
+        throw('Validation failed - translations missing - run ember i18n:download');
       }
       compiledTranslationFiles.forEach((path) => {
         const compiledTranslationsFile = fs.readFileSync(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outdoorsyco/ember-cli-crowdin",
-  "version": "3.3.1",
+  "version": "3.3.2-beta.1",
   "description": "Manages the Crowdin translations for your Ember app from ember-cli",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
allows for `VALIDATE=false ember build --environment production`

For 2 cases:

- the bundlesize check for CI on PR pushes.  If there are new translations in the PR, the validation would fail, unless `ember i18n:upload` had been run.  We don't want to require the developer to do that.
- a developer wants to test out a production build, and doesn't care about having translations

Testing it out here: https://github.com/outdoorsy/outdoorsy-search/pull/1272