### PR TITLE
[monorepo prep] Change the way to find outdoorsy addons

### DIFF
--- a/lib/commands/download.js
+++ b/lib/commands/download.js
@@ -4,6 +4,7 @@ const chalk = require('chalk');
 const unzipper = require('unzipper');
 const loadConfig = require('../utils/config');
 const getClient = require('../utils/client');
+const outdoorsyAddonsWithTranslations = require('../utils/outdoorsy-addons-with-translations');
 const api = require('@outdoorsyco/crowdin-api');
 const waitAndExport = require('../utils/wait-and-export');
 
@@ -26,7 +27,7 @@ module.exports = {
   }) {
     const includeAssets = assets;
     this.parentApp = parentApp;
-    const addons = this._outdoorsyAddonsWithTranslations();
+    const addons = outdoorsyAddonsWithTranslations(parentApp);
     const config = loadConfig(parentApp.root);
     const crowdin = getClient(config);
 
@@ -70,13 +71,6 @@ module.exports = {
       })
     }).catch((error) => {
       throw error;
-    });
-  },
-
-  _outdoorsyAddonsWithTranslations() {
-    return this.parentApp.addons.filter((addon) => {
-      const path = addon.root;
-      return path.includes('outdoorsyco') && fs.existsSync(`${path}/config/crowdin.js`);
     });
   }
 };

--- a/lib/commands/validate.js
+++ b/lib/commands/validate.js
@@ -2,6 +2,7 @@ require('colors');
 const chalk = require('chalk');
 const fs = require('fs');
 const yaml = require('js-yaml');
+const outdoorsyAddonsWithTranslations = require('../utils/outdoorsy-addons-with-translations');
 
 module.exports = {
   name: 'i18n:validate',
@@ -20,7 +21,7 @@ module.exports = {
     this.distLocation = distLocation;
     this.ui = ui;
     this._validateTranslations(parentApp);
-    this._outdoorsyAddonsWithTranslations().forEach((addon) => {
+    outdoorsyAddonsWithTranslations(parentApp).forEach((addon) => {
       this._validateTranslations(addon);
     });
 
@@ -84,12 +85,5 @@ module.exports = {
     } catch (error) {
       throw error;
     }
-  },
-
-  _outdoorsyAddonsWithTranslations() {
-    return this.parentApp.addons.filter((addon) => {
-      const path = addon.root;
-      return path.includes('outdoorsyco') && fs.existsSync(`${path}/config/crowdin.js`);
-    });
   }
 }

--- a/lib/utils/outdoorsy-addons-with-translations.js
+++ b/lib/utils/outdoorsy-addons-with-translations.js
@@ -1,0 +1,10 @@
+const fs = require('fs');
+
+module.exports = function (parentApp) {
+  return parentApp.addons.filter((addon) => {
+    const isOutdoorsyAddon = addon.pkg.name.includes('@outdoorsyco');
+    const hasTranslations = fs.existsSync(`${addon.root}/config/crowdin.js`);
+
+    return isOutdoorsyAddon && hasTranslations;
+  });
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@outdoorsyco/ember-cli-crowdin",
-  "version": "3.3.2",
+  "version": "3.4.0-beta.1",
   "description": "Manages the Crowdin translations for your Ember app from ember-cli",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Changes to using the package name to find outdoorsy addons.  The previous approach would not work in the addon was in the same monorepo as the app.

https://github.com/outdoorsy/outdoorsy-search/pull/1299