### PR TITLE
Possibly fix corrupt file issue

### DIFF
--- a/lib/commands/download.js
+++ b/lib/commands/download.js
@@ -120,7 +120,6 @@ function extractFiles({ parentApp, addons, config, includeAssets, ui }) {
         file.autodrain();
       }
     })
-    .on('close', resolve)
     .on('end', resolve)
     .on('error', reject);
   })

--- a/lib/commands/download.js
+++ b/lib/commands/download.js
@@ -114,8 +114,10 @@ function extractFiles({ parentApp, addons, config, includeAssets, ui }) {
           }
         }
 
-        file.pipe(fs.createWriteStream(fullPath));
-        ui.writeLine(chalk.green(`Writing file ${file.path}`));
+        file.pipe(fs.createWriteStream(fullPath))
+        .on('close', () => {
+          ui.writeLine(chalk.green(`File successfully written: ${file.path}`));
+        });
       } else {
         file.autodrain();
       }

--- a/lib/commands/upload.js
+++ b/lib/commands/upload.js
@@ -22,7 +22,7 @@ module.exports = {
 
     let translations = api.updateFile(config.projectName, { path: config.baseFile}, null, folderName).then(() => {
       this.ui.stopProgress();
-      this.ui.writeLine(chalk.green(`Source tanslations were successfully updated on ${folderName} folder.`));
+      this.ui.writeLine(chalk.green(`Source translations were successfully updated on ${folderName} folder.`));
     }).catch(error =>  {
       this.ui.stopProgress();
       throw new Error(error.message);


### PR DESCRIPTION
I think this _may_ have been the issue we see periodically with corrupted translation files: https://circleci.com/gh/outdoorsy/frontend/18180?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification

I did some testing, and it seemed like sometimes the very last file would not be done processing before the download promise resolved