### PR TITLE
No longer throw on unhandled rejection.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,6 @@
 // eslint-disable-next-line node/no-extraneous-require
 const Funnel = require('broccoli-funnel');
 
-process.on('unhandledRejection', error => {
-  throw error;
-});
-
 module.exports = {
   name: require('./package').name,
   excludeFromBuild: false,


### PR DESCRIPTION
This has been causing ember-cli to crash for certain build issues like syntax errors in templates. It was originally put in place to catch a Crowdin error that hasn’t been happening anymore, so should be fine to remove