### PR TITLE
Async build command, and change download to not wait

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,8 +34,7 @@ module.exports = {
         'tests/dummy/app/**'
       ],
       parserOptions: {
-        sourceType: 'script',
-        ecmaVersion: 2015
+        sourceType: 'script'
       },
       env: {
         browser: false,

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
 
   postBuild(results) {
     if (
-      process.env.VALIDATE !== 'false'
+      process.env.VALIDATE
       && !['test', 'development'].includes(this.app.env)
       // if this is ember-cli-crowdin itself, there's nothing to validate
       && !this.project.root.includes('ember-cli-crowdin')

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ module.exports = {
       'i18n:check': require('./lib/commands/check'),
       'i18n:report': require('./lib/commands/report'),
       'i18n:validate': require('./lib/commands/validate'),
+      'i18n:build': require('./lib/commands/build'),
       'i18n:download': require('./lib/commands/download'),
       'i18n:setup': require('./lib/commands/setup'),
       'i18n:upload': require('./lib/commands/upload')

--- a/lib/commands/build.js
+++ b/lib/commands/build.js
@@ -1,0 +1,32 @@
+const api = require('@outdoorsyco/crowdin-api');
+const loadConfig = require('../utils/config');
+const chalk = require('chalk');
+
+module.exports = {
+  name: 'i18n:build',
+  description: `Trigger a build of the latest translations`,
+  aliases: ['i18n:b'],
+  availableOptions: [
+    {
+      name: 'async',
+      type: Boolean,
+      default: true,
+      description: 'true: will return immediately; false: will wait for build to complete'
+    }
+  ],
+
+  run: function({ async = true }) {
+    const config = loadConfig(this.project.root);
+    api.setKey(config.apiKey);
+    this.ui.writeLine(`Triggering a crowdin build`);
+    return new Promise((resolve, reject) => {
+      api.exportTranslations(config.projectName, { async: Number(async) }).then((result) => {
+        this.ui.writeLine(`Crowdin build status: ${chalk.green(result.success.status)}`);
+        resolve();
+      }).catch((error) => {
+        reject(error);
+      });
+    })
+  }
+};
+

--- a/lib/commands/download.js
+++ b/lib/commands/download.js
@@ -8,7 +8,6 @@ const outdoorsyAddonsWithTranslations = require('../utils/outdoorsy-addons-with-
 const api = require('@outdoorsyco/crowdin-api');
 const waitAndExport = require('../utils/wait-and-export');
 
-const CACHE_MINUTES = 5;
 const translationCacheDirectory = 'tmp/translation-cache';
 const allTranslationsZip = `${translationCacheDirectory}/all-translations.zip`;
 

--- a/lib/commands/download.js
+++ b/lib/commands/download.js
@@ -16,12 +16,27 @@ module.exports = {
   name: 'i18n:download',
   aliases: ['i18n:dl'],
   availableOptions: [
-    { name: 'assets', type: Boolean, default: true }
+    {
+      name: 'assets',
+      type: Boolean,
+      default: true,
+      description: 'Whether to include non-string assets like images'
+    },
+    {
+      name: 'wait-for-build',
+      type: Boolean,
+      default: false,
+      description: (
+        'Whether to first trigger and wait for a crowdin build' +
+        'If set to false (default), will immediately download latest completed build'
+      )
+    }
   ],
   description: 'Download i18n files from Crowdin, including addons',
 
-  run: function({
+  async run({
     assets = true,
+    waitForBuild = false,
     parentApp = this.project,
     ui = this.ui
   }) {
@@ -32,46 +47,34 @@ module.exports = {
     const crowdin = getClient(config);
 
     ui.writeLine(chalk.cyan(`---- Getting all translations for ${parentApp.pkg.name} ----`));
-
-    // First, check if the zip exists on disk already
-    if (fs.existsSync(allTranslationsZip)) {
-      const stats = fs.statSync(allTranslationsZip);
-      const ageInMinutes = (new Date() - new Date(stats.mtime)) / 1000 / 60;
-      if (ageInMinutes > CACHE_MINUTES) {
-        ui.writeLine(chalk.red('Translations cache expired'));
-      } else {
-        ui.writeLine(chalk.green(
-          `Already have all translations downloaded. Getting files from disk`
-        ));
-        return extractFiles({ parentApp, addons, config, includeAssets, ui });
-      }
-    } else {
-
-      // If not, make sure the directory exists and download translation from crowdin
-      fs.ensureDirSync(translationCacheDirectory);
-    }
-
     api.setKey(config.apiKey);
 
-    ui.writeLine(chalk.yellow(
-      `Building and downloading all assets and translations from crowdin`
-    ));
-
-    return waitAndExport(config.projectName).then(result => {
-      ui.writeLine(`Crowdin build status: ${chalk.green(result.success.status)}`);
-      return new Promise((resolve, reject) => {
-        // Download all translations and write zip to disk
-        crowdin.download().pipe(fs.createWriteStream(allTranslationsZip))
-        .on('finish', () => {
-          return extractFiles({ parentApp, addons, config, includeAssets, ui }).then(() => {
-            resolve();
-          }).catch((error) => {
-            reject(error);
-          });
-        })
+    if (waitForBuild) {
+      ui.writeLine(chalk.yellow(
+        `Building and downloading all assets and translations from crowdin`
+      ));
+      try {
+        const buildResult = await waitAndExport(config.projectName);
+        ui.writeLine(`Crowdin build status: ${chalk.green(buildResult.success.status)}`);
+      } catch (error) {
+        throw(error);
+      }
+    } else {
+      ui.writeLine(chalk.yellow(
+        `Downloading all assets and translations from crowdin`
+      ));
+    }
+    return new Promise((resolve, reject) => {
+      // Download all translations and write zip to disk
+      crowdin.download().pipe(fs.createWriteStream(allTranslationsZip))
+      .on('finish', async () => {
+        try {
+          await extractFiles({ parentApp, addons, config, includeAssets, ui });
+          resolve();
+        } catch (error) {
+          reject(error);
+        }
       })
-    }).catch((error) => {
-      throw error;
     });
   }
 };

--- a/lib/commands/download.js
+++ b/lib/commands/download.js
@@ -65,6 +65,7 @@ module.exports = {
     }
     return new Promise((resolve, reject) => {
       // Download all translations and write zip to disk
+      fs.ensureDirSync(translationCacheDirectory);
       crowdin.download().pipe(fs.createWriteStream(allTranslationsZip))
       .on('finish', async () => {
         try {

--- a/lib/utils/wait-and-export.js
+++ b/lib/utils/wait-and-export.js
@@ -17,12 +17,15 @@ module.exports = function (projectName) {
           console.info(`\nCrowdin is still processing.  Waiting ${WAIT_INTERVAL_SECONDS} seconds…`);
           setTimeout(checkForSuccess, WAIT_INTERVAL_SECONDS * 1000);
         } else {
+          console.info('No builds in progress. Triggering export…')
           api.exportTranslations(projectName).then((result) => {
             resolve(result);
           }).catch((error) => {
             reject(error);
           })
         }
+      }).catch((error) => {
+        reject(error);
       })
     })();
   })

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "push:git": "git push --tags origin HEAD:master"
   },
   "dependencies": {
-    "@outdoorsyco/crowdin-api": "github:outdoorsy/crowdin-api#pass-params-to-get",
+    "@outdoorsyco/crowdin-api": "2.2.0",
     "crowdin-node": "github:outdoorsy/crowdin-node#updates",
     "ember-cli-babel": "^6.12.0",
     "fs-extra": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "push:git": "git push --tags origin HEAD:master"
   },
   "dependencies": {
-    "@outdoorsyco/crowdin-api": "2.1.4",
+    "@outdoorsyco/crowdin-api": "github:outdoorsy/crowdin-api#pass-params-to-get",
     "crowdin-node": "github:outdoorsy/crowdin-node#updates",
     "ember-cli-babel": "^6.12.0",
     "fs-extra": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "rimraf": "^2.6.2"
   },
   "engines": {
-    "node": "6.* || >= 7.* || >= 8.*"
+    "node": "8.* || >= 10.*"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,9 +197,10 @@
   dependencies:
     "@glimmer/di" "^0.2.0"
 
-"@outdoorsyco/crowdin-api@github:outdoorsy/crowdin-api#pass-params-to-get":
+"@outdoorsyco/crowdin-api@2.2.0":
   version "2.2.0"
-  resolved "https://codeload.github.com/outdoorsy/crowdin-api/tar.gz/f8200800fa33c4480cf7e964702a191207cb94f5"
+  resolved "https://registry.yarnpkg.com/@outdoorsyco/crowdin-api/-/crowdin-api-2.2.0.tgz#1b3abdf4613a287c5db8fb62fb2b1cf45c64273c"
+  integrity sha512-6aRb1LJkYi5eO8AOXeZsz3vF0du3ZXE/2TbospZSwe+/WJXvHxyyb4wZ7oEa4AywBngdulypX6fIfGCgKpNOOA==
   dependencies:
     request "^2.81.0"
     request-promise-native "^1.0.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,10 +197,9 @@
   dependencies:
     "@glimmer/di" "^0.2.0"
 
-"@outdoorsyco/crowdin-api@2.1.4":
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/@outdoorsyco/crowdin-api/-/crowdin-api-2.1.4.tgz#e43231fe1696c3c0f618e94c8c8899e85ac60c50"
-  integrity sha512-M73mgT/CN/z08qUJw1aBB+YvIBBDDc2OZTrxWFuYrGlsUqmqW+k1Mi7FQvkehtajLhj5euD5t1MPKAzcJXiAmQ==
+"@outdoorsyco/crowdin-api@github:outdoorsy/crowdin-api#pass-params-to-get":
+  version "2.2.0"
+  resolved "https://codeload.github.com/outdoorsy/crowdin-api/tar.gz/f8200800fa33c4480cf7e964702a191207cb94f5"
   dependencies:
     request "^2.81.0"
     request-promise-native "^1.0.5"


### PR DESCRIPTION
[BREAKING] Additions and changes to Crowdin commands:

- `ember i18n:build`: triggers a crowdin build, and returns immediately without waiting
- `ember i18n:build --async false`: triggers a crowdin build, and waits for it to be done
- `ember i18n:download`: immediately downloads translations, from the latest completed build
- `ember i18n:download --wait-for-build`: triggers a crowdin build, and then downloads translations from that build (like download used to do)


### Dependencies

https://github.com/outdoorsy/crowdin-api/pull/3